### PR TITLE
Added Materialized Info Icon

### DIFF
--- a/src/main/res/drawable/ic_menu_info_24.xml
+++ b/src/main/res/drawable/ic_menu_info_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/src/main/res/layout/fragment_home.xml
+++ b/src/main/res/layout/fragment_home.xml
@@ -100,7 +100,7 @@
                 android:id="@+id/home_button_connection_info"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@android:drawable/ic_menu_info_details"
+                android:src="@drawable/ic_menu_info_24"
                 android:layout_alignTop="@+id/home_text_name"
                 android:layout_alignParentRight="true"
                 android:layout_alignParentEnd="true"/>


### PR DESCRIPTION
Fixes: #112

## Description:
Added **Materialized** SVG Icon on the Home Screen (`fragment_home`) to replace PNG to display the Connection Info which improves the Interface and Scalability on various Screens while running the android app.

### Material Icon Link: https://material.io/resources/icons/?icon=info&style=outline

## Screenshot Before:
![WhatsApp Image 2021-03-24 at 4 43 58 AM](https://user-images.githubusercontent.com/54114888/112231301-7a336300-8c5c-11eb-8cdb-dacc78bde4be.jpeg)

## Screenshot of Materialized Info Icon:
![WhatsApp Image 2021-03-24 at 4 43 58 AM (1)](https://user-images.githubusercontent.com/54114888/112231603-05145d80-8c5d-11eb-8918-362b5aa9c24c.jpeg)