### PR TITLE
Added Update for Material Component Library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'com.jaredrummler:android-device-names:2.0.0'
 
     //materialDesign
-    implementation 'com.google.android.material:material:1.3.0-alpha02'
+    implementation 'com.google.android.material:material:1.3.0'
 
     //leakcanary
     //debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'


### PR DESCRIPTION
## Description:

Added Update  for the Material Components Android library from version `1.3.0-alpha02` to `1.3.0` (Stable Version) which was released on February 5th, 2021. Also tested and verifies on various scenarios while running the android application. 

### Note: There are newer versions of the Library available, but not stable releases therefore needs to be tested even more rigorously if needed to update to the latest version.

### Reference: https://github.com/material-components/material-components-android/releases/tag/1.3.0