### PR TITLE
Added Materialized Icon to Connection Info Dialog Box

### DIFF
--- a/src/main/java/dk/aau/netsec/hostage/ui/fragment/ConnectionInfoDialogFragment.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/fragment/ConnectionInfoDialogFragment.java
@@ -71,7 +71,7 @@ public class ConnectionInfoDialogFragment extends DialogFragment {
 
 		builder.setView(view);
 		builder.setTitle(R.string.title_connection_info);
-		builder.setIcon(getResources().getDrawable(R.drawable.ic_info_dark_grey_icon));
+		builder.setIcon(getResources().getDrawable(R.drawable.ic_outline_info_24));
 		builder.setPositiveButton(R.string.show_records, (dialog, which) -> {
 			showRecords(filterSSID);
 		});

--- a/src/main/res/drawable/ic_outline_info_24.xml
+++ b/src/main/res/drawable/ic_outline_info_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>


### PR DESCRIPTION
Fixes: #116

## Description:
Added Materialized `SVG` Icon on the Connection Info Dialog Box `(fragment_connectioninfo_dialog)` to replace PNG  which improves the Interface and Scalability on various Screens while running the android app.

### Reference Link: https://material.io/resources/icons/?icon=info&style=outline

## Screenshot of Current Dialog Box:
![WhatsApp Image 2021-03-25 at 4 49 32 AM](https://user-images.githubusercontent.com/54114888/112396586-68b68d80-8d26-11eb-9d32-9c1b3255d688.jpeg)

## Screenshot of Improved Dialog Box:
![WhatsApp Image 2021-03-25 at 4 49 32 AM (1)](https://user-images.githubusercontent.com/54114888/112396938-204b9f80-8d27-11eb-8740-e665716abff1.jpeg)