### PR TITLE
Added Update for Apache Qpid Library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,11 +55,11 @@ dependencies {
     // https://mvnrepository.com/artifact/javax.naming/jndi
     implementation files('libs/jndi-1.2.1.jar');
     // https://mvnrepository.com/artifact/org.apache.qpid/qpid-broker-plugins-amqp-0-8-protocol
-    implementation group: 'org.apache.qpid', name: 'qpid-broker-plugins-amqp-0-8-protocol', version: '8.0.0'
+    implementation group: 'org.apache.qpid', name: 'qpid-broker-plugins-amqp-0-8-protocol', version: '8.0.2'
     // https://mvnrepository.com/artifact/org.apache.qpid/qpid-broker-plugins-amqp-1-0-protocol
-    implementation group: 'org.apache.qpid', name: 'qpid-broker-plugins-amqp-1-0-protocol', version: '8.0.0'
+    implementation group: 'org.apache.qpid', name: 'qpid-broker-plugins-amqp-1-0-protocol', version: '8.0.2'
     // https://mvnrepository.com/artifact/org.apache.qpid/qpid-broker-plugins-memory-store
-    implementation group: 'org.apache.qpid', name: 'qpid-broker-plugins-memory-store', version: '8.0.0'
+    implementation group: 'org.apache.qpid', name: 'qpid-broker-plugins-memory-store', version: '8.0.2'
 
     //dependencies of AMQP broker
     // https://mvnrepository.com/artifact/com.google.guava/guava


### PR DESCRIPTION
## Description:

Added Update for the Apache Qpid Broker library from version `8.0.0` to version `8.0.2` which was released on October 22nd, 2020. Also tested and verified on various scenarios while running the android application. The Apache Qpid Broker library is a memory message store broker plug-in.