### PR TITLE
Added Update for Commons IO Library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     testImplementation group: 'com.hierynomus', name: 'smbj', version: '0.10.0'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.7'
 
     //device-Names
     implementation 'com.jaredrummler:android-device-names:2.0.0'


### PR DESCRIPTION
## Description:

Added Update for the Apache Commons IO library from version `2.6` to version `2.7` which was released on May 27th, 2020. Also tested and verified on various scenarios while running the app. The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.