### PR TITLE
Added Update for HiveMQ Client Library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     //moquette
     implementation 'io.moquette:moquette-broker:0.12.1'
     //hive-Mq
-    implementation group: 'com.hivemq', name: 'hivemq-mqtt-client', version: '1.2.0'
+    implementation group: 'com.hivemq', name: 'hivemq-mqtt-client', version: '1.2.1'
 
     //SU Library for root
     implementation 'eu.chainfire:libsuperuser:1.0.0.201704021214'


### PR DESCRIPTION
## Description:

Added Update for the HiveMQ MQTT Client library from version `1.2.0` to version `1.2.1` which was released on August 9th, 2020. Also tested and verified on various scenarios while running the android application. HiveMQ MQTT Client is an MQTT compatible and feature-rich high-performance Java client library with different API flavors and backpressure support