### PR TITLE
Added Update for SNMP4J Library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation files('libs/alfresco-jlan.jar')
     implementation files('libs/nineoldandroids-2.4.0.jar')
     implementation files('libs/cryptix-jce-provider.jar')
-    implementation group: 'org.snmp4j', name: 'snmp4j', version: '3.4.2'
+    implementation group: 'org.snmp4j', name: 'snmp4j', version: '3.4.4'
     // https://mvnrepository.com/artifact/org.snmp4j/snmp4j-agent
     implementation group: 'org.snmp4j', name: 'snmp4j-agent', version: '3.3.4'
     implementation files('libs/VirusTotalAPI.jar')


### PR DESCRIPTION
## Description:

Added Update for the SNMP4J Library from version `3.4.2` to version `3.4.4` which was released on November 14, 2020. Also tested and verified on various scenarios while running the Android Application.