### PR TITLE
Added Update for Firebase Crashlytics library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 }
 dependencies {
     //firebase
-    implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
+    implementation 'com.google.firebase:firebase-crashlytics:17.4.1'
     implementation 'com.google.firebase:firebase-analytics:17.5.0'
     implementation 'com.google.firebase:firebase-core:17.5.0'
     implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'


### PR DESCRIPTION
## Description:

Added Update for the Firebase Crashlytics library from version `17.2.1` to its latest version `17.4.1` which was released on March 27th, 2021. Also tested and verified on various scenarios while running the android application.