### PR TITLE
Fixed Statistics screen TextView

### DIFF
--- a/src/main/res/layout/fragment_statistics.xml
+++ b/src/main/res/layout/fragment_statistics.xml
@@ -46,6 +46,7 @@
                         android:layout_height="match_parent"
                         android:textAppearance="?android:attr/textAppearanceMedium"
                         android:textAlignment="center"
+                        android:gravity="center"
                         android:id="@+id/title_text_view" />
                 </LinearLayout>
                 <!-- PLOT LAYOUT -->


### PR DESCRIPTION
Fixes: #146

## Description:

Center aligned the TextView to make it look more like a header title and symmetric.

## Screenshot of current Statistics screen:
![WhatsApp Image 2021-04-30 at 1 54 55 AM](https://user-images.githubusercontent.com/54114888/116646367-7a2e2d80-a995-11eb-9181-41a900eb2aa9.jpeg)

## Screenshot of fixed Statistics screen:
![WhatsApp Image 2021-04-30 at 1 54 31 AM](https://user-images.githubusercontent.com/54114888/116646589-135d4400-a996-11eb-85e7-ba6807a1d036.jpeg)
