### PR TITLE
Added Update for Play services Auth library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:17.0.0'
     implementation 'com.google.android.gms:play-services-analytics:17.0.0'
     implementation 'com.google.android.gms:play-services-maps:17.0.0'
-    implementation 'com.google.android.gms:play-services-auth:18.1.0'
+   implementation 'com.google.android.gms:play-services-auth:19.0.0'
     //greenDao
     implementation 'org.roboguice:roboguice:2.0'
     implementation 'org.greenrobot:greendao:3.3.0'


### PR DESCRIPTION
## Description:

Added Update for the Google Play services Auth library from version `18.1.0` to its latest version `19.0.0` which was released on November 9th, 2020. Also tested and verified on various scenarios while running the android application.