### PR TITLE
Materialized Icons added for Notifications Settings screen

### DIFF
--- a/src/main/res/drawable/ic_set_sound.xml
+++ b/src/main/res/drawable/ic_set_sound.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7.58,4.08L6.15,2.65C3.75,4.48 2.17,7.3 2.03,10.5h2c0.15,-2.65 1.51,-4.97 3.55,-6.42zM19.97,10.5h2c-0.15,-3.2 -1.73,-6.02 -4.12,-7.85l-1.42,1.43c2.02,1.45 3.39,3.77 3.54,6.42zM18,11c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2v-5zM12,22c0.14,0 0.27,-0.01 0.4,-0.04 0.65,-0.14 1.18,-0.58 1.44,-1.18 0.1,-0.24 0.15,-0.5 0.15,-0.78h-4c0.01,1.1 0.9,2 2.01,2z"/>
+</vector>

--- a/src/main/res/drawable/ic_vibration.xml
+++ b/src/main/res/drawable/ic_vibration.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M0,15h2L2,9L0,9v6zM3,17h2L5,7L3,7v10zM22,9v6h2L24,9h-2zM19,17h2L21,7h-2v10zM16.5,3h-9C6.67,3 6,3.67 6,4.5v15c0,0.83 0.67,1.5 1.5,1.5h9c0.83,0 1.5,-0.67 1.5,-1.5v-15c0,-0.83 -0.67,-1.5 -1.5,-1.5zM16,19L8,19L8,5h8v14z"/>
+</vector>

--- a/src/main/res/xml/settings_preferences.xml
+++ b/src/main/res/xml/settings_preferences.xml
@@ -95,7 +95,8 @@
 				android:defaultValue="false"
 				android:key="pref_vibration"
 				android:summary="@string/pref_vibration_summ"
-				android:title="@string/pref_vibration" />
+				android:title="@string/pref_vibration"
+				android:icon="@drawable/ic_vibration"/>
 
 			<RingtonePreference
 				android:defaultValue="content://settings/system/notification_sound"
@@ -104,7 +105,8 @@
 				android:showDefault="true"
 				android:showSilent="true"
 				android:summary="@string/pref_alarm_summ"
-				android:title="@string/pref_alarm" />
+				android:title="@string/pref_alarm"
+				android:icon="@drawable/ic_set_sound"/>
 		</PreferenceCategory>
 		</PreferenceScreen>
 


### PR DESCRIPTION
Fixes: #152

## Description:

Added Materialized Icons on Notifications Settings screen to improve the user interface.

## Screenshot of current Notifications Settings screen:
![WhatsApp Image 2021-04-30 at 2 23 36 AM](https://user-images.githubusercontent.com/54114888/116650208-6509cc80-a99e-11eb-881f-bfc209ab74a8.jpeg)

## Screenshot of improved Notifications Settings screen:
![WhatsApp Image 2021-04-30 at 2 26 49 AM](https://user-images.githubusercontent.com/54114888/116650405-a69a7780-a99e-11eb-9def-a3d389246e33.jpeg)
