### PR TITLE
Protocols load bug

### DIFF
--- a/src/main/java/dk/aau/netsec/hostage/Hostage.java
+++ b/src/main/java/dk/aau/netsec/hostage/Hostage.java
@@ -641,8 +641,13 @@ public class Hostage extends Service {
      * @param protocolName The name of the protocol
      * @return Returns the default port number, if the protocol is implemented.
      * Else returns -1.
+     * @throws NullPointerException gets thrown if {@link ImplementProtocols} has not yet been
+     * initialized.
      */
-    private int getDefaultPort(String protocolName) {
+    private int getDefaultPort(String protocolName) throws NullPointerException{
+        if (implementedProtocols == null){
+            throw new NullPointerException();
+        }
         for (Protocol protocol : implementedProtocols) {
             if (protocolName.equals(protocol.toString())) {
                 return protocol.getPort();

--- a/src/main/java/dk/aau/netsec/hostage/Hostage.java
+++ b/src/main/java/dk/aau/netsec/hostage/Hostage.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -13,6 +14,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONObject;
+
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -53,756 +55,740 @@ import static dk.aau.netsec.hostage.commons.HelperUtils.getBSSID;
  * Service controls start and stop of protocol listener. Notifies GUI about
  * events happening in the background. Creates Notifications to inform the user
  * what it happening.
- * 
+ *
  * @author Mihai Plasoianu
  * @author Lars Pandikow
  * @author Wulf Pfeiffer
  */
 public class Hostage extends Service {
 
-	private HashMap<String, Boolean> mProtocolActiveAttacks;
-	private DaoSession dbSession;
-	public static int prefix;
-	boolean activeHandlers = false;
-	boolean bssidSeen = false;
-	boolean listening = false;
+    private HashMap<String, Boolean> mProtocolActiveAttacks;
+    private DaoSession dbSession;
+    public static int prefix;
+    boolean activeHandlers = false;
+    boolean bssidSeen = false;
+    boolean listening = false;
 
-	public class LocalBinder extends Binder {
-		public Hostage getService() {
-			return Hostage.this;
-		}
-	}
+    public class LocalBinder extends Binder {
+        public Hostage getService() {
+            return Hostage.this;
+        }
+    }
 
-	/**
-	 * Task to find out the external IP.
-	 * 
-	 */
-	private class SetExternalIPTask extends AsyncTask<String, Void, String> {
-		@Override
-		protected String doInBackground(String... url) {
-			String ipAddress = null;
-			try {
-				HttpClient httpclient = new DefaultHttpClient();
-				HttpGet httpget = new HttpGet(url[0]);
-				HttpResponse response;
-				response = httpclient.execute(httpget);
-				HttpEntity entity = response.getEntity();
-				entity.getContentLength();
-				String str = EntityUtils.toString(entity);
-				JSONObject json_data = new JSONObject(str);
-				ipAddress = json_data.getString("ip");
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-			return ipAddress;
-		}
+    /**
+     * Task to find out the external IP.
+     */
+    private class SetExternalIPTask extends AsyncTask<String, Void, String> {
+        @Override
+        protected String doInBackground(String... url) {
+            String ipAddress = null;
+            try {
+                HttpClient httpclient = new DefaultHttpClient();
+                HttpGet httpget = new HttpGet(url[0]);
+                HttpResponse response;
+                response = httpclient.execute(httpget);
+                HttpEntity entity = response.getEntity();
+                entity.getContentLength();
+                String str = EntityUtils.toString(entity);
+                JSONObject json_data = new JSONObject(str);
+                ipAddress = json_data.getString("ip");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return ipAddress;
+        }
 
-		@Override
-		protected void onPostExecute(String result) {
-			connectionInfoEditor.putString(getString(R.string.connection_info_external_ip), result);
-			connectionInfoEditor.commit();
-			notifyUI(this.getClass().getName(), new String[] { getString(R.string.broadcast_connectivity) });
-		}
-	}
+        @Override
+        protected void onPostExecute(String result) {
+            connectionInfoEditor.putString(getString(R.string.connection_info_external_ip), result);
+            connectionInfoEditor.commit();
+            notifyUI(this.getClass().getName(), new String[]{getString(R.string.broadcast_connectivity)});
+        }
+    }
 
-	private static class FindPrefix extends AsyncTask<String, String, Integer> {
-		@Override
-		protected Integer doInBackground(String... strings) {
-			try {
-				return HelperUtils.getPrefix(strings);
-			} catch (UnknownHostException e) {
-				e.printStackTrace();
-			}
-			return 24;
-		}
+    private static class FindPrefix extends AsyncTask<String, String, Integer> {
+        @Override
+        protected Integer doInBackground(String... strings) {
+            try {
+                return HelperUtils.getPrefix(strings);
+            } catch (UnknownHostException e) {
+                e.printStackTrace();
+            }
+            return 24;
+        }
 
-		@Override
-		protected void onPostExecute(Integer result) {
-			prefix = result;
-		}
-	}
+        @Override
+        protected void onPostExecute(Integer result) {
+            prefix = result;
+        }
+    }
 
 
-	private static class ImplementProtocols extends AsyncTask<Void,Void,LinkedList<Protocol>>{
+    private static class ImplementProtocols extends AsyncTask<Void, Void, LinkedList<Protocol>> {
 
-		@Override
-		protected LinkedList<Protocol> doInBackground(Void... voids) {
-			return getImplementedProtocols();
-		}
+        @Override
+        protected LinkedList<Protocol> doInBackground(Void... voids) {
+            return getImplementedProtocols();
+        }
 
-		@Override
-		protected void onPostExecute(LinkedList<Protocol> result) {
-			implementedProtocols = result;
-		}
-	}
+        @Override
+        protected void onPostExecute(LinkedList<Protocol> result) {
+            implementedProtocols = result;
+        }
+    }
 
-	private static WeakReference<Context> context;
+    private static WeakReference<Context> context;
 
-	/**
-	 * Returns the application context.
-	 * 
-	 * @return context.
-	 */
-	public static Context getContext() {
-		return context.get();
-	}
+    /**
+     * Returns the application context.
+     *
+     * @return context.
+     */
+    public static Context getContext() {
+        return context.get();
+    }
 
-	private static LinkedList<Protocol> implementedProtocols;
-	private CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<Listener>();
-	private SharedPreferences connectionInfo;
-	private Editor connectionInfoEditor;
-	private final IBinder mBinder = new LocalBinder();
+    private static LinkedList<Protocol> implementedProtocols;
+    private CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<Listener>();
+    private SharedPreferences connectionInfo;
+    private Editor connectionInfoEditor;
+    private final IBinder mBinder = new LocalBinder();
 
-	/**
-	 * Receiver for connectivity change broadcast.
-	 * 
-	 * @see MainActivity #BROADCAST
-	 */
-	private BroadcastReceiver netReceiver = new BroadcastReceiver() {
-		@Override
-		public void onReceive(Context context, Intent intent) {
-			String bssid_old = connectionInfo.getString(getString(R.string.connection_info_bssid), "");
-			String bssid_new;
-			if (HelperUtils.isCellurarConnected(context)){
-				bssid_new = HelperUtils.getNetworkClass(context);
-			}
-			else {
-				 bssid_new = getBSSID(context);
-			}
-			if (bssid_new == null || !bssid_new.equals(bssid_old)) {
-				deleteConnectionData();
-				updateConnectionInfo();
-				notifyUI(this.getClass().getName(), new String[] { getString(R.string.broadcast_connectivity) });
-			}
-		}
-	};
+    /**
+     * Receiver for connectivity change broadcast.
+     *
+     * @see MainActivity #BROADCAST
+     */
+    private BroadcastReceiver netReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String bssid_old = connectionInfo.getString(getString(R.string.connection_info_bssid), "");
+            String bssid_new;
+            if (HelperUtils.isCellurarConnected(context)) {
+                bssid_new = HelperUtils.getNetworkClass(context);
+            } else {
+                bssid_new = getBSSID(context);
+            }
+            if (bssid_new == null || !bssid_new.equals(bssid_old)) {
+                deleteConnectionData();
+                updateConnectionInfo();
+                notifyUI(this.getClass().getName(), new String[]{getString(R.string.broadcast_connectivity)});
+            }
+        }
+    };
 
-	public List<Listener> getListeners() {
-		return listeners;
-	}
+    public List<Listener> getListeners() {
+        return listeners;
+    }
 
-	/**
-	 * Determines the number of active connections for a protocol running on its
-	 * default port.
-	 * 
-	 * @param protocolName
-	 *            The protocol name
-	 * @return Number of active connections
-	 */
-	public int getNumberOfActiveConnections(String protocolName) {
-		int port = getDefaultPort(protocolName);
-		return getNumberOfActiveConnections(protocolName, port);
-	}
+    /**
+     * Determines the number of active connections for a protocol running on its
+     * default port.
+     *
+     * @param protocolName The protocol name
+     * @return Number of active connections
+     */
+    public int getNumberOfActiveConnections(String protocolName) {
+        int port = getDefaultPort(protocolName);
+        return getNumberOfActiveConnections(protocolName, port);
+    }
 
-	/**
-	 * Determines the number of active connections for a protocol running on the
-	 * given port.
-	 * 
-	 * @param protocolName
-	 *            The protocol name
-	 * @param port
-	 *            Specific port
-	 * @return Number of active connections
-	 */
-	public int getNumberOfActiveConnections(String protocolName, int port) {
-		for (Listener listener : listeners) {
-			if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
-				return listener.getHandlerCount();
-			}
-		}
-		return 0;
-	}
+    /**
+     * Determines the number of active connections for a protocol running on the
+     * given port.
+     *
+     * @param protocolName The protocol name
+     * @param port         Specific port
+     * @return Number of active connections
+     */
+    public int getNumberOfActiveConnections(String protocolName, int port) {
+        for (Listener listener : listeners) {
+            if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
+                return listener.getHandlerCount();
+            }
+        }
+        return 0;
+    }
 
-	/**
-	 * Determines if there any listener is currently running.
-	 * 
-	 * @return True if there is a running listener, else false.
-	 */
-	public boolean hasRunningListeners() {
-		for (Listener listener : listeners) {
-			if (listener.isRunning())
-				return true;
-		}
-		return false;
-	}
+    /**
+     * Determines if there any listener is currently running.
+     *
+     * @return True if there is a running listener, else false.
+     */
+    public boolean hasRunningListeners() {
+        for (Listener listener : listeners) {
+            if (listener.isRunning())
+                return true;
+        }
+        return false;
+    }
 
-	/**
-	 * Determines if a protocol with the given name is running on its default
-	 * port.
-	 * 
-	 * @param protocolName
-	 *            The protocol name
-	 * @return True if protocol is running, else false.
-	 */
-	public boolean isRunning(String protocolName) {
-		int port = getDefaultPort(protocolName);
-		return isRunning(protocolName, port);
-	}
+    /**
+     * Determines if a protocol with the given name is running on its default
+     * port.
+     *
+     * @param protocolName The protocol name
+     * @return True if protocol is running, else false.
+     */
+    public boolean isRunning(String protocolName) {
+        int port = getDefaultPort(protocolName);
+        return isRunning(protocolName, port);
+    }
 
-	public boolean isRunningAnyPort(String protocolName){
-		for(Listener listener: listeners){
-			if(listener.getProtocolName().equals(protocolName)){
-				if(listener.isRunning()) return true;
-			}
-		}
+    public boolean isRunningAnyPort(String protocolName) {
+        for (Listener listener : listeners) {
+            if (listener.getProtocolName().equals(protocolName)) {
+                if (listener.isRunning()) return true;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * Determines if a protocol with the given name is running on the given
-	 * port.
-	 * 
-	 * @param protocolName
-	 *            The protocol name
-	 * @param port
-	 *            Specific port
-	 * @return True if protocol is running, else false.
-	 */
-	public boolean isRunning(String protocolName, int port) {
-		for (Listener listener : listeners) {
-			if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
-				return listener.isRunning();
-			}
-		}
-		return false;
-	}
+    /**
+     * Determines if a protocol with the given name is running on the given
+     * port.
+     *
+     * @param protocolName The protocol name
+     * @param port         Specific port
+     * @return True if protocol is running, else false.
+     */
+    public boolean isRunning(String protocolName, int port) {
+        for (Listener listener : listeners) {
+            if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
+                return listener.isRunning();
+            }
+        }
+        return false;
+    }
 
-	/**
-	 * Notifies the GUI about a event.
-	 * 
-	 * @param sender
-	 *            Source where the event took place.
-	 * @param values
-	 *            Detailed information about the event.
-	 */
-	public synchronized void notifyUI(String sender, String[] values) {
-		createNotification();
-		// Send Notification
-		if (sender.equals(Handler.class.getName()) && values[0].equals(getString(R.string.broadcast_started))) {
-			this.mProtocolActiveAttacks.put(values[1], true);
-			attackNotification();
-		}
-		informUI(sender,values);
-	}
+    /**
+     * Notifies the GUI about a event.
+     *
+     * @param sender Source where the event took place.
+     * @param values Detailed information about the event.
+     */
+    public synchronized void notifyUI(String sender, String[] values) {
+        createNotification();
+        // Send Notification
+        if (sender.equals(Handler.class.getName()) && values[0].equals(getString(R.string.broadcast_started))) {
+            this.mProtocolActiveAttacks.put(values[1], true);
+            attackNotification();
+        }
+        informUI(sender, values);
+    }
 
-	private void informUI(String sender, String[] values){
-		// Inform UI of Preference Change
-		Intent intent = new Intent(getString(R.string.broadcast));
-		intent.putExtra("SENDER", sender);
-		intent.putExtra("VALUES", values);
-		Log.i("Sender", sender);
-		LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
-	}
+    private void informUI(String sender, String[] values) {
+        // Inform UI of Preference Change
+        Intent intent = new Intent(getString(R.string.broadcast));
+        intent.putExtra("SENDER", sender);
+        intent.putExtra("VALUES", values);
+        Log.i("Sender", sender);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+    }
 
-	@Override
-	public IBinder onBind(Intent intent) {
-		return mBinder;
-	}
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mBinder;
+    }
 
-	@Override
-	public void onCreate() {
-		super.onCreate();
-		context = new WeakReference<>(getApplicationContext());
-		loadConnectionInfoEditor();
-		loadProtocols();
-		mProtocolActiveAttacks = new HashMap<>();
-		createNotification();
-		registerNetReceiver();
-		loadConnectionInfo();
-	}
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        context = new WeakReference<>(getApplicationContext());
+        loadConnectionInfoEditor();
+        loadProtocols();
+        mProtocolActiveAttacks = new HashMap<>();
+        createNotification();
+        registerNetReceiver();
+        loadConnectionInfo();
+    }
 
-	private void loadConnectionInfo(){
-		updateConnectionInfo();
-	}
+    private void loadConnectionInfo() {
+        updateConnectionInfo();
+    }
 
-	private void loadConnectionInfoEditor(){
-		connectionInfo = getSharedPreferences(getString(R.string.connection_info), Context.MODE_PRIVATE);
-		connectionInfoEditor = connectionInfo.edit();
-		connectionInfoEditor.apply();
-	}
+    private void loadConnectionInfoEditor() {
+        connectionInfo = getSharedPreferences(getString(R.string.connection_info), Context.MODE_PRIVATE);
+        connectionInfoEditor = connectionInfo.edit();
+        connectionInfoEditor.apply();
+    }
 
-	private void loadProtocols(){
-		ImplementProtocols implementProtocols = new ImplementProtocols();
-		implementProtocols.execute();
-	}
+    private void loadProtocols() {
+        ImplementProtocols implementProtocols = new ImplementProtocols();
+        implementProtocols.execute();
+    }
 
-	@Override
-	public void onDestroy() {
-		cancelNotification();
-		unregisterNetReceiver();
-		super.onDestroy();
-	}
+    @Override
+    public void onDestroy() {
+        cancelNotification();
+        unregisterNetReceiver();
+        super.onDestroy();
+    }
 
-	@Override
-	public int onStartCommand(Intent intent, int flags, int startId) {
-		// We want this service to continue running until it is explicitly
-		// stopped, so return sticky.
-		//startMultiStage(); The method moved in PreferenceHostageFragment class along with stopMultiStage().
-		return START_STICKY;
-	}
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        // We want this service to continue running until it is explicitly
+        // stopped, so return sticky.
+        //startMultiStage(); The method moved in PreferenceHostageFragment class along with stopMultiStage().
+        return START_STICKY;
+    }
 
-	/**
-	 * Starts the listener for the specified protocol. Creates a new
-	 * HoneyService if no matching HoneyListener is found.
-	 * 
-	 * @param protocolName
-	 *            Name of the protocol that should be started.
-	 */
-	public boolean startListener(String protocolName) {
-		return startListener(protocolName, getDefaultPort(protocolName));
-	}
+    /**
+     * Starts the listener for the specified protocol. Creates a new
+     * HoneyService if no matching HoneyListener is found.
+     *
+     * @param protocolName Name of the protocol that should be started.
+     */
+    public boolean startListener(String protocolName) {
+        return startListener(protocolName, getDefaultPort(protocolName));
+    }
 
-	/**
-	 * Starts the listener for the specified protocol and port. Creates a new
-	 * HoneyService if no matching HoneyListener is found.
-	 * 
-	 * @param protocolName
-	 *            Name of the protocol that should be started.
-	 * @param port
-	 *            The port number in which the listener should run.
-	 */
-	public boolean startListener(String protocolName, int port) {
-		for (Listener listener : listeners) {
-			if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
-				if (!listener.isRunning()) {
-					if (listener.start()) {
-						return true;
-					}
-					Toast.makeText(getApplicationContext(), protocolName + " SERVICE COULD NOT BE STARTED!", Toast.LENGTH_SHORT).show();
-					return false;
-				}
+    /**
+     * Starts the listener for the specified protocol and port. Creates a new
+     * HoneyService if no matching HoneyListener is found.
+     *
+     * @param protocolName Name of the protocol that should be started.
+     * @param port         The port number in which the listener should run.
+     */
+    public boolean startListener(String protocolName, int port) {
+        for (Listener listener : listeners) {
+            if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
+                if (!listener.isRunning()) {
+                    if (listener.start()) {
+                        return true;
+                    }
+                    Toast.makeText(getApplicationContext(), protocolName + " SERVICE COULD NOT BE STARTED!", Toast.LENGTH_SHORT).show();
+                    return false;
+                }
 
-			}
-		}
-		Listener listener = createListener(protocolName, port);
-		if (listener != null) {
-			if (listener.start()) {
-				return true;
-			}
-		}
+            }
+        }
+        Listener listener = createListener(protocolName, port);
+        if (listener != null) {
+            if (listener.start()) {
+                return true;
+            }
+        }
 
-		Toast.makeText(getApplicationContext(), protocolName + " SERVICE COULD NOT BE STARTED!", Toast.LENGTH_SHORT).show();
-		return false;
-	}
+        Toast.makeText(getApplicationContext(), protocolName + " SERVICE COULD NOT BE STARTED!", Toast.LENGTH_SHORT).show();
+        return false;
+    }
 
-	/**
-	 * Starts all listeners which are not already running.
-	 */
-	public void startListeners() {
-		for (Listener listener : listeners) {
-			if (!listener.isRunning()) {
-				listener.start();
-			}
-		}
-		// Toast.makeText(getApplicationContext(), "SERVICES STARTED!",
-		// Toast.LENGTH_SHORT).show();
-	}
+    /**
+     * Starts all listeners which are not already running.
+     */
+    public void startListeners() {
+        for (Listener listener : listeners) {
+            if (!listener.isRunning()) {
+                listener.start();
+            }
+        }
+        // Toast.makeText(getApplicationContext(), "SERVICES STARTED!",
+        // Toast.LENGTH_SHORT).show();
+    }
 
-	/**
-	 * Stops the listener for the specified protocol.
-	 * 
-	 * @param protocolName
-	 *            Name of the protocol that should be stopped.
-	 */
-	public void stopListener(String protocolName) {
-		stopListener(protocolName, getDefaultPort(protocolName));
-	}
+    /**
+     * Stops the listener for the specified protocol.
+     *
+     * @param protocolName Name of the protocol that should be stopped.
+     */
+    public void stopListener(String protocolName) {
+        stopListener(protocolName, getDefaultPort(protocolName));
+    }
 
-	/**
-	 * Stops the listener for the specified protocol.
-	 * 
-	 * @param protocolName
-	 *            Name of the protocol that should be stopped.
-	 * @param port
-	 *            The port number in which the listener is running.
-	 */
-	public void stopListener(String protocolName, int port) {
-		for (Listener listener : listeners) {
-			if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
-				if (listener.isRunning()) {
-					listener.stop();
-					mProtocolActiveAttacks.remove(protocolName);
-				}
-			}
-		}
-		// Toast.makeText(getApplicationContext(), protocolName +
-		// " SERVICE STOPPED!", Toast.LENGTH_SHORT).show();
-	}
-	
+    /**
+     * Stops the listener for the specified protocol.
+     *
+     * @param protocolName Name of the protocol that should be stopped.
+     * @param port         The port number in which the listener is running.
+     */
+    public void stopListener(String protocolName, int port) {
+        for (Listener listener : listeners) {
+            if (listener.getProtocolName().equals(protocolName) && listener.getPort() == port) {
+                if (listener.isRunning()) {
+                    listener.stop();
+                    mProtocolActiveAttacks.remove(protocolName);
+                }
+            }
+        }
+        // Toast.makeText(getApplicationContext(), protocolName +
+        // " SERVICE STOPPED!", Toast.LENGTH_SHORT).show();
+    }
 
-	public void stopListenerAllPorts(String protocolName){
-		for(Listener listener: listeners){
-			if(listener.getProtocolName().equals(protocolName)){
-				if(listener.isRunning()){
-					listener.stop();
-					mProtocolActiveAttacks.remove(protocolName);
-				}
-			}
-		}
-	}
-	/**
-	 * Stops all running listeners.
-	 */
-	public void stopListeners() {
-		for (Listener listener : listeners) {
-			if (listener.isRunning()) {
-				listener.stop();
-				mProtocolActiveAttacks.remove(listener.getProtocolName());
-			}
-		}
-		// Toast.makeText(getApplicationContext(), "SERVICES STOPPED!",
-		// Toast.LENGTH_SHORT).show();
-	}
 
-	/**
-	 * Updates the notification when a attack is registered.
-	 */
-	private void attackNotification() {
-		SharedPreferences defaultPref = PreferenceManager.getDefaultSharedPreferences(this);
-		String strRingtonePreference = defaultPref.getString("pref_notification_sound", "content://settings/system/notification_sound");
+    public void stopListenerAllPorts(String protocolName) {
+        for (Listener listener : listeners) {
+            if (listener.getProtocolName().equals(protocolName)) {
+                if (listener.isRunning()) {
+                    listener.stop();
+                    mProtocolActiveAttacks.remove(protocolName);
+                }
+            }
+        }
+    }
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			CharSequence name = "Under Attack";
-			int importance = NotificationManager.IMPORTANCE_DEFAULT;
-			NotificationChannel channel = new NotificationChannel("32",name,importance);
-			channel.setDescription("this");
-			NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+    /**
+     * Stops all running listeners.
+     */
+    public void stopListeners() {
+        for (Listener listener : listeners) {
+            if (listener.isRunning()) {
+                listener.stop();
+                mProtocolActiveAttacks.remove(listener.getProtocolName());
+            }
+        }
+        // Toast.makeText(getApplicationContext(), "SERVICES STOPPED!",
+        // Toast.LENGTH_SHORT).show();
+    }
 
-			mNotificationManager.createNotificationChannel(channel);
-			Notification.Builder notificationBuilder = new Notification.Builder(this,"32");
-			notificationBuilder.setContentTitle(getString(R.string.app_name)).setTicker(getString(R.string.honeypot_live_threat))
-					.setContentText(getString(R.string.honeypot_live_threat)).setSmallIcon(R.drawable.ic_service_red).setAutoCancel(true).setWhen(System.currentTimeMillis())
-					.setSound(Uri.parse(strRingtonePreference));
+    /**
+     * Updates the notification when a attack is registered.
+     */
+    private void attackNotification() {
+        SharedPreferences defaultPref = PreferenceManager.getDefaultSharedPreferences(this);
+        String strRingtonePreference = defaultPref.getString("pref_notification_sound", "content://settings/system/notification_sound");
 
-			if (defaultPref.getBoolean("pref_vibration", false)) {
-				channel.setVibrationPattern(new long[] { 100, 200, 100, 200 });
-			}else{
-				channel.setVibrationPattern(new long[]{ 0 });
-			}
-			channel.enableVibration(true);
-			Notification notification = notificationBuilder.setOngoing(true)
-					.build();
-			startForeground(2, notification);
-		}
-	}
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = "Under Attack";
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel("32", name, importance);
+            channel.setDescription("this");
+            NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
-	/**
-	 * Cancels the Notification
-	 */
-	private void cancelNotification() {
-		NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-		mNotificationManager.cancel(1);
-	}
+            mNotificationManager.createNotificationChannel(channel);
+            Notification.Builder notificationBuilder = new Notification.Builder(this, "32");
+            notificationBuilder.setContentTitle(getString(R.string.app_name)).setTicker(getString(R.string.honeypot_live_threat))
+                    .setContentText(getString(R.string.honeypot_live_threat)).setSmallIcon(R.drawable.ic_service_red).setAutoCancel(true).setWhen(System.currentTimeMillis())
+                    .setSound(Uri.parse(strRingtonePreference));
 
-	/**
-	 * Creates a HoneyListener for a given protocol on a specific port. After
-	 * creation the HoneyListener is not started. Checks if the protocol is
-	 * implemented first.
-	 * 
-	 * @param protocolName
-	 *            Name of the protocol
-	 * @param port
-	 *            Port on which to start the HoneyListener
-	 * @return Returns the created HoneyListener, if creation failed returns
-	 *         null.
-	 */
-	private Listener createListener(String protocolName, int port) {
-		for (Protocol protocol : implementedProtocols) {
-			if (protocolName.equals(protocol.toString())) {
-				if(protocolName.equals("MQTT")) {
-					return addMQTTListener(protocol, port);
-				}
-				if(protocolName.equals("COAP")) {
-					return addCOAPListener(protocol, port);
-				}
-				if(protocolName.equals("AMQP")){
-					return addAMQPListener(protocol,port);
-				}
-				Listener listener = new Listener(this, protocol, port);
-				listeners.add(listener);
-				return listener;
-			}
-		}
-		return null;
-	}
+            if (defaultPref.getBoolean("pref_vibration", false)) {
+                channel.setVibrationPattern(new long[]{100, 200, 100, 200});
+            } else {
+                channel.setVibrationPattern(new long[]{0});
+            }
+            channel.enableVibration(true);
+            Notification notification = notificationBuilder.setOngoing(true)
+                    .build();
+            startForeground(2, notification);
+        }
+    }
 
-	private MQTTListener addMQTTListener(Protocol protocolName, int port){
-		MQTTListener listener = new MQTTListener(this, protocolName, port);
-		listeners.add(listener);
-		return listener;
-	}
+    /**
+     * Cancels the Notification
+     */
+    private void cancelNotification() {
+        NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        mNotificationManager.cancel(1);
+    }
 
-	private COAPListener addCOAPListener(Protocol protocolName, int port){
-		COAPListener listener = new COAPListener(this, protocolName, port);
-		listeners.add(listener);
-		return listener;
-	}
+    /**
+     * Creates a HoneyListener for a given protocol on a specific port. After
+     * creation the HoneyListener is not started. Checks if the protocol is
+     * implemented first.
+     *
+     * @param protocolName Name of the protocol
+     * @param port         Port on which to start the HoneyListener
+     * @return Returns the created HoneyListener, if creation failed returns
+     * null.
+     */
+    private Listener createListener(String protocolName, int port) {
+        for (Protocol protocol : implementedProtocols) {
+            if (protocolName.equals(protocol.toString())) {
+                if (protocolName.equals("MQTT")) {
+                    return addMQTTListener(protocol, port);
+                }
+                if (protocolName.equals("COAP")) {
+                    return addCOAPListener(protocol, port);
+                }
+                if (protocolName.equals("AMQP")) {
+                    return addAMQPListener(protocol, port);
+                }
+                Listener listener = new Listener(this, protocol, port);
+                listeners.add(listener);
+                return listener;
+            }
+        }
+        return null;
+    }
 
-	private AMQPListener addAMQPListener(Protocol protocolName, int port){
-		AMQPListener listener = new AMQPListener(this, protocolName, port);
-		listeners.add(listener);
-		return listener;
-	}
+    private MQTTListener addMQTTListener(Protocol protocolName, int port) {
+        MQTTListener listener = new MQTTListener(this, protocolName, port);
+        listeners.add(listener);
+        return listener;
+    }
 
-	/**
-	 * Creates a Notification in the notification bar.
-	 */
-	private synchronized void createNotification() {
-		if (MainActivity.getInstance() == null) {
-			return; // prevent NullPointerException
-		}
+    private COAPListener addCOAPListener(Protocol protocolName, int port) {
+        COAPListener listener = new COAPListener(this, protocolName, port);
+        listeners.add(listener);
+        return listener;
+    }
 
-		checkNetworkPreviousInfection();
+    private AMQPListener addAMQPListener(Protocol protocolName, int port) {
+        AMQPListener listener = new AMQPListener(this, protocolName, port);
+        listeners.add(listener);
+        return listener;
+    }
 
-		PendingIntent resultPendingIntent = intentNotificationGenerator();
+    /**
+     * Creates a Notification in the notification bar.
+     */
+    private synchronized void createNotification() {
+        if (MainActivity.getInstance() == null) {
+            return; // prevent NullPointerException
+        }
 
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			CharSequence name = "Under Attack";
-			int importance = NotificationManager.IMPORTANCE_DEFAULT;
-			NotificationChannel channel = new NotificationChannel("42",name,importance);
-			channel.setDescription("this");
+        checkNetworkPreviousInfection();
 
-			NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        PendingIntent resultPendingIntent = intentNotificationGenerator();
 
-			mNotificationManager.createNotificationChannel(channel);
-			Notification.Builder notificationBuilder = new Notification.Builder(this,"42");
-			notificationBuilder.setContentTitle(getString(R.string.app_name)).setWhen(System.currentTimeMillis());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = "Under Attack";
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel("42", name, importance);
+            channel.setDescription("this");
+
+            NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+            mNotificationManager.createNotificationChannel(channel);
+            Notification.Builder notificationBuilder = new Notification.Builder(this, "42");
+            notificationBuilder.setContentTitle(getString(R.string.app_name)).setWhen(System.currentTimeMillis());
             notificationIconBuilder(listening, activeHandlers, bssidSeen, notificationBuilder);
-			notificationBuilder.setContentIntent(resultPendingIntent);
+            notificationBuilder.setContentIntent(resultPendingIntent);
 
-			Notification notification = notificationBuilder.setOngoing(true)
-					.setPriority(Notification.PRIORITY_DEFAULT)
-					.build();
-			startForeground(3, notification);
+            Notification notification = notificationBuilder.setOngoing(true)
+                    .setPriority(Notification.PRIORITY_DEFAULT)
+                    .build();
+            startForeground(3, notification);
 
-		}
-	}
+        }
+    }
 
-	private void checkNetworkPreviousInfection(){
-		dbSession = HostageApplication.getInstances().getDaoSession();
-		AttackRecordDAO attackRecordDAO = new AttackRecordDAO(dbSession);
+    private void checkNetworkPreviousInfection() {
+        dbSession = HostageApplication.getInstances().getDaoSession();
+        AttackRecordDAO attackRecordDAO = new AttackRecordDAO(dbSession);
 
-		for (Listener listener : listeners) {
-			if (listener.isRunning())
-				listening = true;
-			if (listener.getHandlerCount() > 0) {
-				activeHandlers = true;
-			}
-			if (attackRecordDAO.bssidSeen(listener.getProtocolName(), getBSSID(getApplicationContext()))) {
-				bssidSeen = true;
-			}
-		}
+        for (Listener listener : listeners) {
+            if (listener.isRunning())
+                listening = true;
+            if (listener.getHandlerCount() > 0) {
+                activeHandlers = true;
+            }
+            if (attackRecordDAO.bssidSeen(listener.getProtocolName(), getBSSID(getApplicationContext()))) {
+                bssidSeen = true;
+            }
+        }
 
-	}
+    }
 
-	/**
-	 * Selects the appropriate icon for the notification.
-	 * @param listening listener for protocols
-	 * @param activeHandlers active Handlers
-	 * @param bssidSeen checks if this bssid is already seen
-	 * @param notificationBuilder builds the notification
-	 */
-	private void notificationIconBuilder(boolean listening,boolean activeHandlers,boolean bssidSeen,Notification.Builder notificationBuilder){
-		if (!listening) {
-			notificationBuilder.setSmallIcon(R.drawable.ic_launcher);
-			notificationBuilder.setContentText(getString(R.string.hostage_not_monitoring));
-		} else if (activeHandlers) {
-			notificationBuilder.setSmallIcon(R.drawable.ic_service_red);
-			notificationBuilder.setContentText(getString(R.string.hostage_live_threat));
-		} else if (bssidSeen) {
-			notificationBuilder.setSmallIcon(R.drawable.ic_service_yellow);
-			notificationBuilder.setContentText(getString(R.string.hostage_past_threat));
-		} else {
-			notificationBuilder.setSmallIcon(R.drawable.ic_service_green);
-			notificationBuilder.setContentText(getString(R.string.hostage_no_threat));
-		}
-	}
+    /**
+     * Selects the appropriate icon for the notification.
+     *
+     * @param listening           listener for protocols
+     * @param activeHandlers      active Handlers
+     * @param bssidSeen           checks if this bssid is already seen
+     * @param notificationBuilder builds the notification
+     */
+    private void notificationIconBuilder(boolean listening, boolean activeHandlers, boolean bssidSeen, Notification.Builder notificationBuilder) {
+        if (!listening) {
+            notificationBuilder.setSmallIcon(R.drawable.ic_launcher);
+            notificationBuilder.setContentText(getString(R.string.hostage_not_monitoring));
+        } else if (activeHandlers) {
+            notificationBuilder.setSmallIcon(R.drawable.ic_service_red);
+            notificationBuilder.setContentText(getString(R.string.hostage_live_threat));
+        } else if (bssidSeen) {
+            notificationBuilder.setSmallIcon(R.drawable.ic_service_yellow);
+            notificationBuilder.setContentText(getString(R.string.hostage_past_threat));
+        } else {
+            notificationBuilder.setSmallIcon(R.drawable.ic_service_green);
+            notificationBuilder.setContentText(getString(R.string.hostage_no_threat));
+        }
+    }
 
-	/**
-	 * Generates the intent for the notification.
-	 * @return the pending Intent
-	 */
-	private PendingIntent intentNotificationGenerator(){
-		TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
-		stackBuilder.addParentStack(MainActivity.class);
+    /**
+     * Generates the intent for the notification.
+     *
+     * @return the pending Intent
+     */
+    private PendingIntent intentNotificationGenerator() {
+        TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
+        stackBuilder.addParentStack(MainActivity.class);
 
-		Intent intent = MainActivity.getInstance().getIntent();
-		intent.addCategory(Intent.ACTION_MAIN);
-		intent.addCategory(Intent.CATEGORY_LAUNCHER);
-		intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-		intent.setAction("SHOW_HOME");
-		stackBuilder.addNextIntent(intent);
+        Intent intent = MainActivity.getInstance().getIntent();
+        intent.addCategory(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+        intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        intent.setAction("SHOW_HOME");
+        stackBuilder.addNextIntent(intent);
 
-		PendingIntent resultPendingIntent = PendingIntent.getActivity(MainActivity.getContext(), 0, intent, 0); //stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent resultPendingIntent = PendingIntent.getActivity(MainActivity.getContext(), 0, intent, 0); //stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
 
-		return resultPendingIntent;
+        return resultPendingIntent;
 
-	}
+    }
 
-	/**
-	 * Deletes all session related data.
-	 */
-	private void deleteConnectionData() {
-		connectionInfoEditor.clear();
-		connectionInfoEditor.commit();
-	}
+    /**
+     * Deletes all session related data.
+     */
+    private void deleteConnectionData() {
+        connectionInfoEditor.clear();
+        connectionInfoEditor.commit();
+    }
 
-	/**
-	 * Returns the default port number, if the protocol is implemented.
-	 * 
-	 * @param protocolName
-	 *            The name of the protocol
-	 * @return Returns the default port number, if the protocol is implemented.
-	 *         Else returns -1.
-	 */
-	private int getDefaultPort(String protocolName) {
-		for (Protocol protocol : implementedProtocols) {
-			if (protocolName.equals(protocol.toString())) {
-				return protocol.getPort();
-			}
-		}
-		return -1;
-	}
+    /**
+     * Returns the default port number, if the protocol is implemented.
+     *
+     * @param protocolName The name of the protocol
+     * @return Returns the default port number, if the protocol is implemented.
+     * Else returns -1.
+     */
+    private int getDefaultPort(String protocolName) {
+        for (Protocol protocol : implementedProtocols) {
+            if (protocolName.equals(protocol.toString())) {
+                return protocol.getPort();
+            }
+        }
+        return -1;
+    }
 
-	/**
-	 * Returns an LinkedList<String> with the names of all implemented
-	 * protocols.
-	 * 
-	 * @return ArrayList of
-	 *         {@link Protocol
-	 *         Protocol}
-	 */
-	private static LinkedList<Protocol> getImplementedProtocols() {
-		String[] protocols = Hostage.getContext().getResources().getStringArray(R.array.protocols);
-		String packageName = Protocol.class.getPackage().getName();
-		LinkedList<Protocol> implementedProtocols = new LinkedList<>();
+    /**
+     * Returns an LinkedList<String> with the names of all implemented
+     * protocols.
+     *
+     * @return ArrayList of
+     * {@link Protocol
+     * Protocol}
+     */
+    private static LinkedList<Protocol> getImplementedProtocols() {
+        String[] protocols = Hostage.getContext().getResources().getStringArray(R.array.protocols);
+        String packageName = Protocol.class.getPackage().getName();
+        LinkedList<Protocol> implementedProtocols = new LinkedList<>();
 
-		for (String protocol : protocols) {
-			try {
-				implementedProtocols.add((Protocol) Class.forName(String.format("%s.%s", packageName, protocol)).newInstance());
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		}
-		return implementedProtocols;
-	}
+        for (String protocol : protocols) {
+            try {
+                implementedProtocols.add((Protocol) Class.forName(String.format("%s.%s", packageName, protocol)).newInstance());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return implementedProtocols;
+    }
 
 
-	// Notifications
+    // Notifications
 
-	/**
-	 * Register broadcast receiver for connectivity changes
-	 */
-	private void registerNetReceiver() {
-		// register BroadcastReceiver on network state changes
-		IntentFilter intent = new IntentFilter();
-		intent.addAction(ConnectivityManager.CONNECTIVITY_ACTION); // "android.net.conn.CONNECTIVITY_CHANGE"
-		registerReceiver(netReceiver, intent);
-	}
+    /**
+     * Register broadcast receiver for connectivity changes
+     */
+    private void registerNetReceiver() {
+        // register BroadcastReceiver on network state changes
+        IntentFilter intent = new IntentFilter();
+        intent.addAction(ConnectivityManager.CONNECTIVITY_ACTION); // "android.net.conn.CONNECTIVITY_CHANGE"
+        registerReceiver(netReceiver, intent);
+    }
 
-	/**
-	 * Unregister broadcast receiver for connectivity changes
-	 */
-	private void unregisterNetReceiver() {
-		unregisterReceiver(netReceiver);
-	}
-	
+    /**
+     * Unregister broadcast receiver for connectivity changes
+     */
+    private void unregisterNetReceiver() {
+        unregisterReceiver(netReceiver);
+    }
 
-	public boolean hasProtocolActiveAttacks(String protocol){
-		if(!mProtocolActiveAttacks.containsKey(protocol)) return false;
-		return mProtocolActiveAttacks.get(protocol);
-	}
 
-	public boolean hasActiveAttacks(){
-		for(boolean b: mProtocolActiveAttacks.values()){
-			if(b) return true;
-		}
+    public boolean hasProtocolActiveAttacks(String protocol) {
+        if (!mProtocolActiveAttacks.containsKey(protocol)) return false;
+        return mProtocolActiveAttacks.get(protocol);
+    }
 
-		return false;
-	}
+    public boolean hasActiveAttacks() {
+        for (boolean b : mProtocolActiveAttacks.values()) {
+            if (b) return true;
+        }
 
-	/**
-	 * Updates the connection info and saves them in the the SharedPreferences
-	 * for session data. Works for both types of connection (4g and wifi).
-	 * 
-	 * @see MainActivity #CONNECTION_INFO
-	 */
-	private void updateConnectionInfo() {
-		if (!HelperUtils.isNetworkAvailable(getContext()) ){
-			return; // no connection
-		}
+        return false;
+    }
 
-		if (HelperUtils.isCellurarConnected(getContext())) {
-			addCellularInfo(getContext());
+    /**
+     * Updates the connection info and saves them in the the SharedPreferences
+     * for session data. Works for both types of connection (4g and wifi).
+     *
+     * @see MainActivity #CONNECTION_INFO
+     */
+    private void updateConnectionInfo() {
+        if (!HelperUtils.isNetworkAvailable(getContext())) {
+            return; // no connection
+        }
 
-		}else {
-			final WifiManager wifiManager = (WifiManager) getContext().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-			final WifiInfo connectionInfo = wifiManager.getConnectionInfo();
+        if (HelperUtils.isCellurarConnected(getContext())) {
+            addCellularInfo(getContext());
 
-			if (connectionInfo == null) {
-				return; // no wifi connection
-			}
-			final DhcpInfo dhcpInfo = wifiManager.getDhcpInfo();
-			if (dhcpInfo == null) {
-				return;
-			}
+        } else {
+            final WifiManager wifiManager = (WifiManager) getContext().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+            final WifiInfo connectionInfo = wifiManager.getConnectionInfo();
 
-			addWifiInfo(connectionInfo,dhcpInfo);
-		}
+            if (connectionInfo == null) {
+                return; // no wifi connection
+            }
+            final DhcpInfo dhcpInfo = wifiManager.getDhcpInfo();
+            if (dhcpInfo == null) {
+                return;
+            }
 
-		findExternalIp();
+            addWifiInfo(connectionInfo, dhcpInfo);
+        }
 
-		this.mProtocolActiveAttacks.clear();
-	}
+        findExternalIp();
 
-	private void addCellularInfo(Context context){
-		int ipAddress = HelperUtils.getCellularIP();
-		String ssid= HelperUtils.getNetworkClass(context);
-		String bssid= HelperUtils.getNetworkClass(context);
-		int netmask= 0;
+        this.mProtocolActiveAttacks.clear();
+    }
 
-		updateEditor(ssid,bssid, ipAddress, netmask);
+    private void addCellularInfo(Context context) {
+        int ipAddress = HelperUtils.getCellularIP();
+        String ssid = HelperUtils.getNetworkClass(context);
+        String bssid = HelperUtils.getNetworkClass(context);
+        int netmask = 0;
 
-	}
+        updateEditor(ssid, bssid, ipAddress, netmask);
 
-	private void addWifiInfo(WifiInfo connectionInfo,DhcpInfo dhcpInfo){
-		String ssid = connectionInfo.getSSID();
-		int ipAddress = dhcpInfo.ipAddress;
-		String bssid= connectionInfo.getBSSID();
-		int netmask= dhcpInfo.netmask;
+    }
 
-		if (ssid.startsWith("\"") && ssid.endsWith("\"")) { // trim those quotes
-			ssid = ssid.substring(1, ssid.length() - 1);
-		}
+    private void addWifiInfo(WifiInfo connectionInfo, DhcpInfo dhcpInfo) {
+        String ssid = connectionInfo.getSSID();
+        int ipAddress = dhcpInfo.ipAddress;
+        String bssid = connectionInfo.getBSSID();
+        int netmask = dhcpInfo.netmask;
 
-		FindPrefix findPrefix = new FindPrefix();
-		findPrefix.execute(HelperUtils.inetAddressToString(netmask));
+        if (ssid.startsWith("\"") && ssid.endsWith("\"")) { // trim those quotes
+            ssid = ssid.substring(1, ssid.length() - 1);
+        }
 
-		updateEditor( ssid,bssid, ipAddress, netmask);
-	}
+        FindPrefix findPrefix = new FindPrefix();
+        findPrefix.execute(HelperUtils.inetAddressToString(netmask));
 
-	private void findExternalIp(){
-		SetExternalIPTask externalIPTask = new SetExternalIPTask();
-		externalIPTask.execute("https://api.ipify.org?format=json");
-	}
+        updateEditor(ssid, bssid, ipAddress, netmask);
+    }
 
-	/**
-	 * Updates the editor for the connection
-	 *
-	 * @see MainActivity #CONNECTION_INFO
-	 */
-	public void updateEditor(String ssid, String bssid, int ipAddress, int netmask){
-		SharedPreferences pref = getContext().getSharedPreferences(getString(R.string.connection_info), Context.MODE_PRIVATE);
-		Editor editor = pref.edit();
+    private void findExternalIp() {
+        SetExternalIPTask externalIPTask = new SetExternalIPTask();
+        externalIPTask.execute("https://api.ipify.org?format=json");
+    }
 
-		editor.putString(getString(R.string.connection_info_ssid), ssid);
-		editor.putString(getString(R.string.connection_info_bssid), bssid);
-		editor.putInt(getString(R.string.connection_info_internal_ip), ipAddress);
-		editor.putInt(getString(R.string.connection_info_subnet_mask), netmask);
+    /**
+     * Updates the editor for the connection
+     *
+     * @see MainActivity #CONNECTION_INFO
+     */
+    public void updateEditor(String ssid, String bssid, int ipAddress, int netmask) {
+        SharedPreferences pref = getContext().getSharedPreferences(getString(R.string.connection_info), Context.MODE_PRIVATE);
+        Editor editor = pref.edit();
 
-		editor.apply();
-	}
+        editor.putString(getString(R.string.connection_info_ssid), ssid);
+        editor.putString(getString(R.string.connection_info_bssid), bssid);
+        editor.putInt(getString(R.string.connection_info_internal_ip), ipAddress);
+        editor.putInt(getString(R.string.connection_info_subnet_mask), netmask);
+
+        editor.apply();
+    }
 
 
 }

--- a/src/main/java/dk/aau/netsec/hostage/ui/fragment/ServicesFragment.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/fragment/ServicesFragment.java
@@ -204,13 +204,20 @@ public class ServicesFragment extends TrackerFragment {
                         setStateNotConnected();
                     } else { // we have a connection
                         // activate all protocols
-                        for (String protocol : protocols) {
+                        try {
+                            for (String protocol : protocols) {
                                 if (MainActivity.getInstance().getHostageService() != null
                                         && !MainActivity.getInstance().getHostageService().isRunning(protocol)) {
                                     MainActivity.getInstance().getHostageService().startListener(protocol);
                                 }
+                            }
+
+                            setStateActive();
+                        } catch (NullPointerException ne) {
+                            Toast.makeText(getContext(), R.string.error_activating_services, Toast.LENGTH_SHORT).show();
+                            setStateNotActive();
                         }
-                        setStateActive();
+
                     }
                 } else { // switch deactivated
                     if (MainActivity.getInstance().getHostageService() != null) {

--- a/src/main/java/dk/aau/netsec/hostage/ui/fragment/ServicesFragment.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/fragment/ServicesFragment.java
@@ -16,6 +16,7 @@ import android.widget.CompoundButton;
 import android.widget.ListView;
 import android.widget.Switch;
 import android.widget.TextView;
+import android.widget.Toast;
 
 
 import androidx.appcompat.app.AlertDialog;
@@ -51,7 +52,7 @@ public class ServicesFragment extends TrackerFragment {
     private ArrayList<ServicesListItem> protocolList;
 
     private DaoSession dbSession = HostageApplication.getInstances().getDaoSession();
-    private DAOHelper daoHelper = new DAOHelper(dbSession,getActivity());
+    private DAOHelper daoHelper = new DAOHelper(dbSession, getActivity());
 
     private String[] protocols;
     private SharedPreferences mConnectionInfo;
@@ -86,13 +87,12 @@ public class ServicesFragment extends TrackerFragment {
      */
     public void updateUI() {
         if (!HelperUtils.isNetworkAvailable(getActivity())) {
-            if(!MainActivity.getInstance().getHostageService().hasRunningListeners()) {
+            if (!MainActivity.getInstance().getHostageService().hasRunningListeners()) {
                 mServicesSwitchService.setOnCheckedChangeListener(null);
                 setStateNotConnected();
                 setStateNotActive();
                 mServicesSwitchService.setOnCheckedChangeListener(switchChangeListener);
-            }
-            else{
+            } else {
                 mServicesSwitchService.setOnCheckedChangeListener(null);
                 setStateNotConnected();
                 mServicesSwitchService.setChecked(true);
@@ -150,8 +150,8 @@ public class ServicesFragment extends TrackerFragment {
     /**
      * most important method of this class
      *
-     * @param inflater the inflater
-     * @param container the container
+     * @param inflater           the inflater
+     * @param container          the container
      * @param savedInstanceState the saved instance state
      * @return rootView
      */
@@ -160,7 +160,7 @@ public class ServicesFragment extends TrackerFragment {
         super.onCreateView(inflater, container, savedInstanceState);
 
         this.inflater = inflater;
-        this.container= container;
+        this.container = container;
         this.savedInstanceState = savedInstanceState;
         rootView = inflater.inflate(R.layout.fragment_services, container, false);
         assignViews();
@@ -195,7 +195,8 @@ public class ServicesFragment extends TrackerFragment {
                                 .setTitle(R.string.information)
                                 .setMessage(R.string.wifi_not_connected_msg)
                                 .setPositiveButton(android.R.string.ok,
-                                        (dialog, which) -> { }
+                                        (dialog, which) -> {
+                                        }
                                 )
                                 .setIcon(android.R.drawable.ic_dialog_info)
                                 .show();
@@ -234,7 +235,7 @@ public class ServicesFragment extends TrackerFragment {
     }
 
     @Deprecated
-    private void checkGhost(String protocol){
+    private void checkGhost(String protocol) {
         if (protocol.equals("GHOST") && mProfile.mGhostActive) {
             mGhostPorts = mProfile.getGhostPorts();
             if (mGhostPorts.length != 0) {
@@ -274,7 +275,7 @@ public class ServicesFragment extends TrackerFragment {
      * sets main switch to true
      */
     private void setStateActive() {
-            mServicesSwitchService.setChecked(true);
+        mServicesSwitchService.setChecked(true);
     }
 
     /**
@@ -300,7 +301,7 @@ public class ServicesFragment extends TrackerFragment {
     @Override
     public void onStop() {
         super.onStop();
-        if(rootView!=null) {
+        if (rootView != null) {
             mServicesSwitchService.setOnCheckedChangeListener(null);
 //            unbindDrawables(rootView);
 //            rootView=null;
@@ -325,10 +326,10 @@ public class ServicesFragment extends TrackerFragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if(rootView!=null) {
+        if (rootView != null) {
             mServicesSwitchService.setOnCheckedChangeListener(null);
             unbindDrawables(rootView);
-            rootView=null;
+            rootView = null;
         }
         if (mReceiver != null)
             unregisterBroadcastReceiver();

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -280,4 +280,5 @@
     <string name="nfc_not_available">NFC ist nicht verfügbar</string>
     <string name="nfc_enable_beam">Android Beam Aktivieren</string>
     <string name="nfc_hold_phones_together">Halten Sie Telefone zusammen, um Daten zu senden oder empfangen.</string>
+    <string name="error_activating_services">Versuchen Sie es später nochmals.</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -303,6 +303,7 @@
     <string name="nfc_not_available">NFC is not available on this device</string>
     <string name="nfc_enable_beam">Enable Android Beam before synchronizing.</string>
     <string name="nfc_hold_phones_together">Hold phones together to send or receive data.</string>
+    <string name="error_activating_services">Could not activate. Please try again later.</string>
 
 
 <!-- TODO: Remove or change this placeholder text -->

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -219,8 +219,8 @@
     <string name="PERFORMING_TASK_AS_CLIENT">Acting as Client.</string>
 
     <string name="ACTIONBAR_TITLE">WifiDirect Synchronization</string>
-    <string name="PROGRESS_TITLE_LOADING">Loading...</string>
-    <string name="PROGRESS_TITLE_CONNECTING">Connecting...</string>
+    <string name="PROGRESS_TITLE_LOADING">Loading…</string>
+    <string name="PROGRESS_TITLE_CONNECTING">Connecting…</string>
     <string name="PROGRESS_TITLE_SYNC">Synchronize</string>
 
 


### PR DESCRIPTION
Fixes #172 

**Root cause investigation**
The _Services_ fragment loads a list of implemented protocos in the background. Trigerring the _Monitor Services_ switch uses the list of implemented protocols.

On slower devices (emulator, debugging), user actions can trigger the switch, before the list of implemented protocols is fully loaded. A `NullPointerException` is thrown from the `getDefaultPort` method of the `Hostage` class and crashes the app.

**Implemented solution**
On a rare occasion of _Monitor Services_ being activated before the list of implemented protocols is loaded, the `NullPointerExeption` is caught in the `OnCheckedStateListener` in the `ServiceFragment` class and the switch is not activated. A Toast instructing user to try again is displayed.


https://user-images.githubusercontent.com/18397619/122120502-cb518e00-ce2a-11eb-8774-f0ce2b17c181.mp4

