### PR TITLE
Fix attacks click crash

### DIFF
--- a/src/main/java/dk/aau/netsec/hostage/ui/fragment/HomeFragment.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/fragment/HomeFragment.java
@@ -424,7 +424,7 @@ public class HomeFragment extends Fragment {
     }
 
     private void loadAttackListener() {
-        String ssid = mConnectionInfo.getString(getString(R.string.connection_info_ssid), "");
+        String ssid = mConnectionInfo.getString(MainActivity.getContext().getString(R.string.connection_info_ssid), "");
         if (!ssid.isEmpty()) {
             ArrayList<String> ssids = new ArrayList<>();
             ssids.add(ssid);


### PR DESCRIPTION
Fixed the issue where the app would crash if the user clicked on the *Attacks* section of the Home fragment.