### PR TITLE
Fix attack crash

### DIFF
--- a/src/main/java/dk/aau/netsec/hostage/Handler.java
+++ b/src/main/java/dk/aau/netsec/hostage/Handler.java
@@ -335,8 +335,7 @@ public class Handler implements Runnable {
 
         try {
             Location latestLocation = CustomLocationManager.getLocationManagerInstance(null).getLatestLocation();
-//		}
-//		if (MyLocationManager.getNewestLocation() != null) {
+
             record.setLatitude(latestLocation.getLatitude());
             record.setLongitude(latestLocation.getLongitude());
             record.setAccuracy(latestLocation.getAccuracy());

--- a/src/main/java/dk/aau/netsec/hostage/location/CustomLocationManager.java
+++ b/src/main/java/dk/aau/netsec/hostage/location/CustomLocationManager.java
@@ -119,10 +119,11 @@ public class CustomLocationManager {
      * If a location permission has previously been denied, it throws a {@link LocationException}
      * <p>
      * If the user has granted a location permission, but no previous location exists, this method
-     * may temporarily return null, in order not to hang while fresh location is retrieved.
+     * will throw.
      *
-     * @return Latest available location. Can return null if location is not ready yet.
-     * @throws LocationException if Location permission was denied by the user.
+     * @return Latest available location. Throws, if location is not available yet.
+     * @throws LocationException if Location permission was denied by the user, or if location
+     *                           is not available yet.
      */
     @Nullable
     public Location getLatestLocation() throws LocationException {
@@ -130,7 +131,7 @@ public class CustomLocationManager {
             return mLatestLocation;
         } else if (!locationPermissionDenied) {
             updateLocation();
-            return mLatestLocation;
+            throw new LocationNotYetAvailableException("Location permission was granted, but location is not available yet");
         } else {
             throw new LocationException("Location permission has not been granted");
         }

--- a/src/main/java/dk/aau/netsec/hostage/location/LocationException.java
+++ b/src/main/java/dk/aau/netsec/hostage/location/LocationException.java
@@ -1,5 +1,7 @@
 package dk.aau.netsec.hostage.location;
 
+import androidx.annotation.Nullable;
+
 /**
  * Custom exception related to Location issues of the {@link CustomLocationManager}
  *
@@ -14,7 +16,7 @@ public class LocationException extends Exception {
      * @param message Exception message. Typically a lacking location permission or inactive
      *                location provider.
      */
-    public LocationException(String message) {
+    public LocationException(@Nullable String message) {
         super(message);
     }
 }

--- a/src/main/java/dk/aau/netsec/hostage/location/LocationNotYetAvailableException.java
+++ b/src/main/java/dk/aau/netsec/hostage/location/LocationNotYetAvailableException.java
@@ -1,0 +1,25 @@
+package dk.aau.netsec.hostage.location;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Custom exception that is to be thrown when Location permission has been granted, but location
+ * could not be obtained timely.
+ *
+ * This allows the {@link CustomLocationManager} distinguish a temporary unavailable location from
+ * other, more general location issues, represented by parent {@link LocationException}.
+ *
+ * @author Filip Adamik
+ * Created on 20/07/2021
+ */
+public class LocationNotYetAvailableException extends LocationException {
+
+    /**
+     * Throw a new exception.
+     *
+     * @param message Exception message.
+     */
+    public LocationNotYetAvailableException(@Nullable String message){
+        super(message);
+    }
+}


### PR DESCRIPTION
Based on the description and the provided error message, it seems like this error is caused when the location permission has been granted, but the location could not be retrieved (yet).

The attack record includes location data (if available) and an unexpected `null` returned from the location provider causes a `NullPointerException`, which in turn crashes the app.

This was fixed by throwing a new exception type `LocationNotYetAvailableException`, instead of returning `null` from the location provider. Since `LocationNotYetAvailableException` is a subclass of `LocationException`, it gets caught and is handled appropriately by the calling method.

I was not able to replicate the error on my devices, so please let me know if the fix does not work and the issue persists. Fixes #200 