### PR TITLE
Add links to Privacy Policy

### DIFF
--- a/src/main/java/dk/aau/netsec/hostage/ui/fragment/PrivacyFragment.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/fragment/PrivacyFragment.java
@@ -1,14 +1,20 @@
 package dk.aau.netsec.hostage.ui.fragment;
 
 import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.Fragment;
 
@@ -22,6 +28,14 @@ import dk.aau.netsec.hostage.R;
  * Created on 01-03-2021
  */
 public class PrivacyFragment extends Fragment {
+
+    private static final String PRIVACY_POLICY_URL = "https://aau-network-security.github.io/HosTaGe/Privacy_policy.html";
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        setHasOptionsMenu(true);
+        super.onCreate(savedInstanceState);
+    }
 
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
@@ -149,6 +163,9 @@ public class PrivacyFragment extends Fragment {
                 "                  periodically for any changes. We will" +
                 "                  notify you of any changes by posting the new Privacy Policy on" +
                 "                  this page." +
+                "                  </p> <p>" +
+                "                   This Privacy Policy is also available at <a href=\""+ PRIVACY_POLICY_URL +"\" target=\"_blank\" rel=\"noopener noreferrer\">"
+                + PRIVACY_POLICY_URL + "</a>"+
                 "                </p> <p>This policy is effective as of 2021-03-08</p> <p><strong>Contact Us</strong></p> <p>" +
                 "                  If you have any questions or suggestions about our" +
                 "                  Privacy Policy, do not hesitate to contact us at hostage@es.aau.dk." +
@@ -168,5 +185,23 @@ public class PrivacyFragment extends Fragment {
         policy.setMovementMethod(LinkMovementMethod.getInstance());
 
         return rootView;
+    }
+
+    @Override
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+        inflater.inflate(R.menu.privacy_policy_menu, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == R.id.privacy_link_open){
+
+            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(PRIVACY_POLICY_URL));
+            startActivity(browserIntent);
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/res/drawable/ic_privacy_tip.xml
+++ b/src/main/res/drawable/ic_privacy_tip.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12c5.16,-1.26 9,-6.45 9,-12V5L12,1L12,1zM11,7h2v2h-2V7zM11,11h2v6h-2V11z"/>
+</vector>

--- a/src/main/res/menu/privacy_policy_menu.xml
+++ b/src/main/res/menu/privacy_policy_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/privacy_link_open"
+        android:icon="@drawable/ic_privacy_tip"
+        android:title="@string/policy_link_open"
+        app:showAsAction="always" />
+</menu>

--- a/src/main/res/values-de/strings.xml
+++ b/src/main/res/values-de/strings.xml
@@ -298,4 +298,5 @@
     <string name="pcap_log_setting_description">PCAP-Protokolle an den unten angegebenen Speicherort schrieben</string>
     <string name="pcap_location_setting_description">Speicherort der Protokollausgabe ändern</string>
     <string name="pcap_log_rotation_name">Log-Rotationsfrequenz</string>
+    <string name="policy_link_open">Im Browser öffnen</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -332,6 +332,7 @@
     <string name="pcap_location_setting_description">Change log output location</string>
     <string name="pcap_log_rotation_name">Specify log rotation frequency</string>
 
+    <string name="policy_link_open">Open in Browser</string>
     <string name="pcap_notification">PCAP logging service is running</string>
     <string name="pcap_notification_text">This could drain battery faster</string>
     <string name="seconds">seconds</string>


### PR DESCRIPTION
Added two links to Privacy Policy within the `PrivacyFragment`. The first one is a menu item with a shield icon that opens the privacy policy online location.

The second one is a sentence within the privacy policy, that contains a link to the privacy policy online location as well.

We may keep either one of these or both.

![Screenshot_20210825-135608](https://user-images.githubusercontent.com/18397619/130786598-4d15b678-1b84-4985-a3ae-35374511bb16.jpg)
