### PR TITLE
Improved Disclaimer Pop-Up

### DIFF
--- a/src/main/java/dk/aau/netsec/hostage/ui/activity/MainActivity.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/activity/MainActivity.java
@@ -356,6 +356,8 @@ public class MainActivity extends AppCompatActivity {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setMessage(Html.fromHtml(getString(R.string.hostage_disclaimer)))
                 .setCancelable(false)
+                .setIcon(R.drawable.ic_disclaimer)
+                .setTitle("Disclaimer")
                 .setPositiveButton(getString(R.string.agree), (dialog, id) -> {
                     // and, if the user accept, you can execute something like this:
                     // We need an Editor object to make preference changes.

--- a/src/main/res/drawable/ic_disclaimer.xml
+++ b/src/main/res/drawable/ic_disclaimer.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/colorPrimary">
+  <path
+      android:fillColor="@color/colorPrimary"
+      android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM16,18L8,18v-2h8v2zM16,14L8,14v-2h8v2zM13,9L13,3.5L18.5,9L13,9z"/>
+</vector>


### PR DESCRIPTION
## Fixes: #221 .

## Description:
Added a Header for the Disclaimer Pop-Up which is displayed when the app is run on the device for the first time. Implemented a Materialised Icon with the primary-color of the app, and a Title specifying Disclaimer to improve the user-interface for users.

## Current Disclaimer Popup Screenshot:
<img src="https://user-images.githubusercontent.com/54114888/160293001-36a79b3a-d4bf-422f-94aa-cf02ec6102c4.jpeg" width="300">

## Improved Disclaimer Popup Screenshot:
<img src="https://user-images.githubusercontent.com/54114888/160293289-3cf3be30-624a-4732-8b37-191b4510cfa1.jpeg" width="300">