### PR TITLE
Added onClick for About section

### DIFF
--- a/src/main/java/dk/aau/netsec/hostage/ui/fragment/AboutFragment.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/fragment/AboutFragment.java
@@ -2,15 +2,20 @@ package dk.aau.netsec.hostage.ui.fragment;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.media.Image;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
+import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
 
@@ -45,6 +50,44 @@ public class AboutFragment extends Fragment {
 		rootView = inflater.inflate(R.layout.fragment_about, container, false);
         PackageManager manager = Hostage.getContext().getPackageManager();
         PackageInfo info = null;
+
+        ImageView img_1 = (ImageView) rootView.findViewById(R.id.img_1);
+        ImageView img_2 = (ImageView) rootView.findViewById(R.id.img_2);
+        ImageView img_3 = (ImageView) rootView.findViewById(R.id.img_3);
+        ImageView img_4 = (ImageView) rootView.findViewById(R.id.img_4);
+
+        img_1.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.tu-darmstadt.de/"));
+                startActivity(browserIntent);
+            }
+        });
+
+        img_2.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.en.aau.dk/"));
+                startActivity(browserIntent);
+            }
+        });
+
+        img_3.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://northsearegion.eu/"));
+                startActivity(browserIntent);
+            }
+        });
+
+        img_4.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://keep.eu/projects/22182/Building-COMpetencies-for-C-EN/"));
+                startActivity(browserIntent);
+            }
+        });
+
         try {
             info = manager.getPackageInfo(Hostage.getContext().getPackageName(), 0);
         } catch (PackageManager.NameNotFoundException e) {

--- a/src/main/res/layout/fragment_about.xml
+++ b/src/main/res/layout/fragment_about.xml
@@ -65,6 +65,7 @@
 
 
 				<ImageView
+					android:id="@+id/img_1"
 					android:layout_width="162dp"
 					android:layout_height="89dp"
 					android:layout_marginLeft="5dp"
@@ -74,6 +75,7 @@
 
 
 				<ImageView
+					android:id="@+id/img_2"
 					android:layout_width="161dp"
 					android:layout_height="89dp"
 					android:layout_marginLeft="5dp"
@@ -118,6 +120,7 @@
 					android:textColor="@android:color/holo_blue_dark"/>
 
 				<ImageView
+					android:id="@+id/img_3"
 					android:layout_width="240dp"
 					android:layout_height="92dp"
 					android:layout_marginLeft="5dp"
@@ -139,6 +142,7 @@
 				android:paddingTop="33dp">
 
 				<ImageView
+					android:id="@+id/img_4"
 					android:layout_width="100dp"
 					android:layout_height="92dp"
 					android:layout_marginLeft="5dp"


### PR DESCRIPTION
## Fixes: #223 .

## Description:
Implemented an onClick for the Logo(s) present in the About Section of the app. When the user clicks on the logo, it will redirect to its relevant website. With the help of this feature, users would be able to know and gain more knowledge about the app and its investors and support.

## Current About Section Screenshot:
<img src="https://user-images.githubusercontent.com/54114888/160648358-a790c8e7-530f-4fe6-a8f7-d29fb8e56917.jpeg" width="300">

## onClick on About Section:
https://user-images.githubusercontent.com/54114888/160650317-e6ff3e4e-5c37-4dc5-9ce9-5d0a537c44b0.mp4