### PR TITLE
Implemented Custom Stylable Toast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     implementation files('libs/nineoldandroids-2.4.0.jar')
     implementation files('libs/cryptix-jce-provider.jar')
     implementation group: 'org.snmp4j', name: 'snmp4j', version: '3.4.5'
+    implementation 'io.github.muddz:styleabletoast:2.4.0'
     // https://mvnrepository.com/artifact/org.snmp4j/snmp4j-agent
     implementation group: 'org.snmp4j', name: 'snmp4j-agent', version: '3.3.6'
     implementation files('libs/VirusTotalAPI.jar')

--- a/src/main/java/dk/aau/netsec/hostage/ui/fragment/RecordOverviewFragment.java
+++ b/src/main/java/dk/aau/netsec/hostage/ui/fragment/RecordOverviewFragment.java
@@ -1,6 +1,7 @@
 package dk.aau.netsec.hostage.ui.fragment;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.FragmentManager;
@@ -11,6 +12,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -62,6 +64,7 @@ import dk.aau.netsec.hostage.ui.popup.AbstractPopupItem;
 import dk.aau.netsec.hostage.ui.popup.SimplePopupItem;
 import dk.aau.netsec.hostage.ui.popup.SimplePopupTable;
 import dk.aau.netsec.hostage.ui.popup.SplitPopupItem;
+import io.github.muddz.styleabletoast.StyleableToast;
 
 
 public class RecordOverviewFragment extends UpNavigatibleFragment implements ChecklistDialog.ChecklistDialogListener, DateTimeDialogFragment.DateTimeDialogFragmentListener {
@@ -822,6 +825,7 @@ public class RecordOverviewFragment extends UpNavigatibleFragment implements Che
     /**
      * Shows a small toast if the data to show is empty (no records).
      */
+    @SuppressLint("ResourceAsColor")
     private void showEmptyDataNotification(){
         if (RecordOverviewFragment.this.noDataNotificationToast == null){
             RecordOverviewFragment.this.noDataNotificationToast =  Toast.makeText(getApplicationContext(), R.string.no_data_notification, Toast.LENGTH_SHORT);
@@ -831,7 +835,12 @@ public class RecordOverviewFragment extends UpNavigatibleFragment implements Che
         if (this.getFilterButton().getVisibility() == View.VISIBLE && this.filter.isSet()){
             this.noDataNotificationToast.setText(R.string.no_data_notification);
         } else {
-            this.noDataNotificationToast.setText(R.string.no_data_notification_no_filter);
+            new StyleableToast
+                    .Builder(getActivity())
+                    .text("No Attacks have been recorded.")
+                    .textColor(Color.WHITE)
+                    .backgroundColor(Color.parseColor("#FF7688"))
+                    .show();
         }
         if (adapter == null || adapter.getData().isEmpty())
             RecordOverviewFragment.this.noDataNotificationToast.show();


### PR DESCRIPTION
## Fixes: #225 .

## Description:
Implemented a Custom Stylable Toast to be displayed which adheres to the Theme of the android app and replaced the default Toast. It improves the styling and theme of the app and the user-interface. The Toast can later be changed very easily if the need arises to do so.

## Current Toast:
<img src="https://user-images.githubusercontent.com/54114888/160813612-847e071f-a0af-4545-b5ee-95c1bceb4dcd.jpeg" width="300">

## Custom Stylable Toast:
<img src="https://user-images.githubusercontent.com/54114888/160814454-67c1e2ba-ab58-4184-b38b-cf93a5bff542.jpeg" width="300">