### PR TITLE
Icon for Privacy Policy Title

### DIFF
--- a/src/main/res/layout/fragment_privacy.xml
+++ b/src/main/res/layout/fragment_privacy.xml
@@ -14,6 +14,7 @@
         android:textColor="@color/black"
         android:textSize="18sp"
         android:textStyle="bold"
+        android:drawableLeft="@drawable/ic_menu_privacy"
         tools:layout_editor_absoluteX="23dp"
         tools:layout_editor_absoluteY="28dp" />
 


### PR DESCRIPTION
## Fixes: #227 .

## Description:
Added an Icon in the Privacy Policy Screen's title same as the one implemented in the Navigation Drawer to access the Privacy Policy screen to improve the user-interface and overall look of the screen while scrolling through the section.

## Current Privacy Policy Screen:
<img src="https://user-images.githubusercontent.com/54114888/160823546-1b259e2d-1abe-434d-aa0d-c00c4cde8f8b.jpeg" width="300">

## Privacy Policy in Navigation Drawer:
<img src="https://user-images.githubusercontent.com/54114888/160823698-932889bf-f8da-459c-af01-e1cd234cda02.jpeg" width="300">

## Improved Privacy Policy Screen:
<img src="https://user-images.githubusercontent.com/54114888/160824260-0d2dc955-a40c-4465-b5f9-6ee48fa0db25.jpeg" width="300">