### PR TITLE
White fillColor of Export Format icon in Records screen

### DIFF
--- a/src/main/res/drawable/ic_export_as.xml
+++ b/src/main/res/drawable/ic_export_as.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM19,19L5,19L5,5h11.17L19,7.83L19,19zM12,12c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3zM6,6h9v4L6,10z"/>
+</vector>

--- a/src/main/res/menu/records_overview_actions.xml
+++ b/src/main/res/menu/records_overview_actions.xml
@@ -3,7 +3,7 @@
 <menu xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:android="http://schemas.android.com/apk/res/android">
 	<item android:id="@+id/records_action_export"
-	      android:icon="@drawable/ic_action_save"
+	      android:icon="@drawable/ic_export_as"
 	      android:title="@string/export_to_storage"
 		  app:showAsAction="always" />
 


### PR DESCRIPTION
## Fixes: #231 .

## Description:
Replaced the existing "Choose export format" grey icon with a Materialised icon with White fillColor in the Records screen to make it uniform along with the Title of the action-bar.

## Screenshot of current Records screen:
<img src="https://user-images.githubusercontent.com/54114888/161396572-8db0beb0-986c-46fd-9103-dbe0ae48938e.jpeg" width="300">

## Screenshot of improved Icon:
<img src="https://user-images.githubusercontent.com/54114888/161396776-21deed40-e06d-45df-816b-0037925b9032.jpeg" width="300">