### PR TITLE
White fillColor of Visualize Icon in Statistics screen

### DIFF
--- a/src/main/res/drawable/ic_sort.xml
+++ b/src/main/res/drawable/ic_sort.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z"/>
+</vector>

--- a/src/main/res/layout/fragment_statistics.xml
+++ b/src/main/res/layout/fragment_statistics.xml
@@ -136,15 +136,15 @@
             android:layout_toLeftOf="@+id/plot_data_button" />
 
         <ImageButton
+            android:id="@+id/plot_data_button"
             style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/plot_data_button"
-            android:src="@drawable/ic_sort_by_size"
-            android:layout_gravity="right"
             android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"/>
+            android:layout_gravity="right"
+            android:src="@drawable/ic_sort" />
 
     </RelativeLayout>
 


### PR DESCRIPTION
## Fixes: #237 .

## Description:
Implemented an Icon to replace the existing Visualize icon of the Statistics screen with White fillColor fr the transcend with the bottom-bar also in SVG format.

## Screenshot of current Visualize icon:
<img src="https://user-images.githubusercontent.com/54114888/161398625-e333485a-b8c2-470c-a90a-dd4195eb5bf1.jpeg" width="300">

## Screenshot of improved Visualize icon:
<img src="https://user-images.githubusercontent.com/54114888/161398701-13ff1e70-e9af-4cb4-bfa3-33faaf8512c6.jpeg" width="300">