### PR TITLE
SVG Icons in Records Screen

### DIFF
--- a/src/main/res/drawable/ic_delete_button.xml
+++ b/src/main/res/drawable/ic_delete_button.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V9c0,-1.1 -0.9,-2 -2,-2H8c-1.1,0 -2,0.9 -2,2v10zM18,4h-2.5l-0.71,-0.71c-0.18,-0.18 -0.44,-0.29 -0.7,-0.29H9.91c-0.26,0 -0.52,0.11 -0.7,0.29L8.5,4H6c-0.55,0 -1,0.45 -1,1s0.45,1 1,1h12c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1z"/>
+</vector>

--- a/src/main/res/drawable/ic_filter_button.xml
+++ b/src/main/res/drawable/ic_filter_button.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,4c2.01,2.59 7,9 7,9v7h4v-7c0,0 4.98,-6.41 7,-9H3z"/>
+</vector>

--- a/src/main/res/drawable/ic_sort_button.xml
+++ b/src/main/res/drawable/ic_sort_button.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z"/>
+</vector>

--- a/src/main/res/layout/fragment_record_detail.xml
+++ b/src/main/res/layout/fragment_record_detail.xml
@@ -166,26 +166,28 @@
 	</LinearLayout>
 
 </ScrollView>
-<RelativeLayout
-    style="@android:style/Widget.Holo.Light.ActionBar.Solid.Inverse"
-    android:orientation="horizontal"
-    android:layout_width="fill_parent"
-    android:layout_height="wrap_content"
-    android:alpha="0.8"
-    android:id="@+id/linearLayout"
-    android:layout_alignParentBottom="true" android:layout_alignParentLeft="true"
-    android:layout_alignParentStart="true">
 
-    <ImageButton
-        style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/DeleteButton"
-        android:src="@drawable/ic_action_discard"
-        android:layout_gravity="right"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentTop="true"
-        android:layout_toLeftOf="@+id/FilterButton"/>
+	<RelativeLayout
+		android:id="@+id/linearLayout"
+		style="@android:style/Widget.Holo.Light.ActionBar.Solid.Inverse"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:layout_alignParentStart="true"
+		android:layout_alignParentLeft="true"
+		android:layout_alignParentBottom="true"
+		android:alpha="0.8"
+		android:orientation="horizontal">
 
-</RelativeLayout>
+		<ImageButton
+			android:id="@+id/DeleteButton"
+			style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_alignParentTop="true"
+			android:layout_alignParentRight="true"
+			android:layout_gravity="right"
+			android:layout_toLeftOf="@+id/FilterButton"
+			android:src="@drawable/ic_action_discard" />
+
+	</RelativeLayout>
 </RelativeLayout>

--- a/src/main/res/layout/fragment_record_list.xml
+++ b/src/main/res/layout/fragment_record_list.xml
@@ -45,33 +45,33 @@
         android:layout_alignParentStart="true">
 
         <ImageButton
-            style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:id="@+id/SortButton"
-            android:src="@drawable/ic_sort_by_size"
-            android:layout_gravity="right"
+            style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true"/>
+            android:layout_gravity="right"
+            android:src="@drawable/ic_sort_button" />
 
         <ImageButton
-            style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:id="@+id/FilterButton"
-            android:src="@drawable/ic_filter"
-            android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/GroupButton"/>
-
-        <ImageButton
             style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/DeleteButton"
-            android:src="@drawable/ic_action_discard"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/FilterButton"/>
+            android:layout_toLeftOf="@+id/GroupButton"
+            android:src="@drawable/ic_filter_button" />
+
+        <ImageButton
+            android:id="@+id/DeleteButton"
+            style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_toLeftOf="@+id/FilterButton"
+            android:src="@drawable/ic_delete_button" />
 
         <ImageButton
             style="@android:style/Widget.DeviceDefault.ActionButton.Overflow"


### PR DESCRIPTION
## Fixes: #239 .

## Description:
Replaced the existing PNG Icons of the Records screen with Materialised SVG Icons to be compatible with large screen sizes and to change colour or shape in an easy manner unlike PNG.

## Screenshot of current Icons in Records screen:
<img src="https://user-images.githubusercontent.com/54114888/161399340-6fe698d2-b297-403b-919f-5fbaeed7520c.jpeg" width="300">

## Screenshot of improved Icons in Records screen:
<img src="https://user-images.githubusercontent.com/54114888/161399413-1a14c82b-9c69-4bd4-8f3c-25131983cc0f.jpeg" width="300">